### PR TITLE
Valid Modifier를 contract로 분리

### DIFF
--- a/contracts/council/Council.sol
+++ b/contracts/council/Council.sol
@@ -1,13 +1,14 @@
 pragma solidity ^0.4.24;
 
 import "contracts/utils/ExtendsOwnable.sol";
+import "contracts/utils/ValidValue.sol";
 
 /**
  * @title Council contract
  *
  * @author Junghoon Seo - <jh.seo@battleent.com>
  */
-contract Council is ExtendsOwnable {
+contract Council is ExtendsOwnable, ValidValue {
     uint256 public cdRate;
     uint256 public depositRate;
     uint256 public initialDeposit;
@@ -19,17 +20,6 @@ contract Council is ExtendsOwnable {
     address public contentsManager;
     address public pixelDistributor;
     address public marketer;
-
-    modifier validRange(uint256 _value) {
-        require(_value > 0);
-        _;
-    }
-
-    modifier validAddress(address _account) {
-        require(_account != address(0));
-        require(_account != address(this));
-        _;
-    }
 
     constructor(
         uint256 _cdRate,

--- a/contracts/marketer/Marketer.sol
+++ b/contracts/marketer/Marketer.sol
@@ -1,18 +1,14 @@
 pragma solidity ^0.4.24;
 
+import "contracts/utils/ValidValue.sol";
+
 /**
  * @title Marketer contract
  *
  * @author Junghoon Seo - <jh.seo@battleent.com>
  */
-contract Marketer {
+contract Marketer is ValidValue {
   mapping (bytes32 => address) marketerInfo;
-
-  modifier validAddress(address _account) {
-      require(_account != address(0));
-      require(_account != address(this));
-      _;
-  }
 
   function getMarketerKey() public validAddress(msg.sender) returns(bytes32) {
       bytes32 key = bytes32(keccak256(abi.encodePacked(msg.sender)));

--- a/contracts/utils/ValidValue.sol
+++ b/contracts/utils/ValidValue.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.4.24;
+
+contract ValidValue {
+  modifier validRange(uint256 _value) {
+      require(_value > 0);
+      _;
+  }
+
+  modifier validAddress(address _account) {
+      require(_account != address(0));
+      require(_account != address(this));
+      _;
+  }
+
+  modifier validString(string _str) {
+      require(bytes(_str).length > 0);
+      _;
+  }
+}


### PR DESCRIPTION
Valid Modifier를 따로 분리 했습니다. ValidValue를 import하고 상속하면 됩니다.
Content Contract에서 사용하는 contentOwner는 멤버변수를 참조하는거라 제외하였습니다.

