### PR TITLE
multiple return 코드 리펙토링

### DIFF
--- a/contracts/supporter/Fund.sol
+++ b/contracts/supporter/Fund.sol
@@ -76,9 +76,7 @@ contract Fund is ContractReceiver, ExtendsOwnable, ValidValue {
         ERC20 token = ERC20(CouncilInterface(council).getToken());
         require(address(token) == _token);
 
-        uint256 index;
-        bool success;
-        (index, success) = findSupporterIndex(_from);
+        (uint256 index, bool success) = findSupporterIndex(_from);
         if (success) {
             supporters[index].investment = supporters[index].investment.add(_value);
         } else {
@@ -119,8 +117,7 @@ contract Fund is ContractReceiver, ExtendsOwnable, ValidValue {
         require(isSupporter(msg.sender));
 
         sponsorshipPool.vote(msg.sender);
-        address[] memory _supporters = new address[](supporters.length);
-        (_supporters,) = getSupporters();
+        (address[] memory _supporters,) = getSupporters();
         uint256 votingCount = sponsorshipPool.getVotingCount(_supporters);
         if (supporters.length.div(2) <= votingCount) {
             uint256 cancelAmount = sponsorshipPool.cancelPool();
@@ -157,10 +154,6 @@ contract Fund is ContractReceiver, ExtendsOwnable, ValidValue {
             supportersIndex = supportersIndex.add(1);
         }
         return (user, investment);
-    }
-
-    function getSupportCount() public view returns (uint256) {
-        return supporters.length;
     }
 
     function getDistributionRate() public view returns (uint256){

--- a/contracts/supporter/FundManager.sol
+++ b/contracts/supporter/FundManager.sol
@@ -49,9 +49,5 @@ contract FundManager is FundManagerInterface, ExtendsOwnable, ValidValue {
         return Fund(_fund).distribution(_total);
     }
 
-    function getSupportCount(address _fund) external view returns (uint256) {
-        return Fund(_fund).getSupportCount();
-    }
-
     event RegisterFund(address _content, address _fund);
 }

--- a/contracts/supporter/FundManagerInterface.sol
+++ b/contracts/supporter/FundManagerInterface.sol
@@ -6,6 +6,4 @@ contract FundManagerInterface {
 
     function distribution(address _fund, uint256 _total) external returns (address[], uint256[]);
 
-    function getSupportCount(address _fund) external view returns (uint256);
-
 }

--- a/contracts/supporter/SponsorshipPool.sol
+++ b/contracts/supporter/SponsorshipPool.sol
@@ -62,9 +62,7 @@ contract SponsorshipPool is Ownable {
     }
 
     function cancelPool() external onlyOwner returns (uint){
-        uint256 index;
-        bool success;
-        (index, success) = getCurrentIndex();
+        (uint256 index, bool success) = getCurrentIndex();
         if (success) {
             pools[index].state = PoolState.CANCEL_PAYMENT;
             return pools[index].amount;
@@ -85,18 +83,14 @@ contract SponsorshipPool is Ownable {
     }
 
     function vote(address _user) external onlyOwner {
-        uint256 index;
-        bool success;
-        (index, success) = getCurrentIndex();
+        (uint256 index, bool success) = getCurrentIndex();
         if (success) {
             pools[index].voting[_user] = true;
         }
     }
 
     function getVotingCount(address[] _users) public view returns (uint256 _count) {
-        uint256 index;
-        bool success;
-        (index, success) = getCurrentIndex();
+        (uint256 index, bool success) = getCurrentIndex();
         if (success) {
             for (uint256 i = 0; i < _users.length; i++) {
                 _count.add(isVoting(index, _users[i]));


### PR DESCRIPTION
구조체 multiple return의 경우 다음 예제와 같이 선언 및 할당이 가능합니다.
(address[] memory _users, uint256[] memory _amounts) = getData();

따라서, FundManager의 support의 갯수를 리턴하는 인터페이스는 제거하였습니다.
