### PR TITLE
신고

### DIFF
--- a/contracts/council/CouncilInterface.sol
+++ b/contracts/council/CouncilInterface.sol
@@ -16,4 +16,5 @@ interface CouncilInterface {
     function getFundManager() external view returns (address);
     function getPixelDistributor() external view returns (address);
     function getMarketer() external view returns (address);
+    function getReport() external view returns (address);
 }

--- a/contracts/deposit/DepositPool.sol
+++ b/contracts/deposit/DepositPool.sol
@@ -70,14 +70,6 @@ contract DepositPool is ExtendsOwnable, ValidValue, ContractReceiver, DepositPoo
     }
 
     /**
-    * @dev 현재 기록된 Content의 Deposit 금액을 반환
-    * @param _content 확인하고자 하는 Content 주소
-    */
-    function getContentDeposit(address _content) external view returns(uint256) {
-        return contentDeposit[_content];
-    }
-
-    /**
     * @dev 위원회가 호출하는 보상지급 처리
     * @param _content 신고한 작품 주소
     * @param _reporter 신고자 주소
@@ -111,7 +103,7 @@ contract DepositPool is ExtendsOwnable, ValidValue, ContractReceiver, DepositPoo
 
         //신고 건이 있으면 완결처리되지 않음
         require(ReportInterface(council.getReport()).getReportCount(_content) == 0);
-        
+
         //작품 완결 시 서포터 비율 가져오고 정산 후 작가에게 정산
         // 누가 실행 시켜야 하는가??
 

--- a/contracts/deposit/DepositPool.sol
+++ b/contracts/deposit/DepositPool.sol
@@ -32,7 +32,7 @@ contract DepositPool is ExtendsOwnable, ValidValue, ContractReceiver, DepositPoo
     * @dev 생성자
     * @param _councilAddress 위원회 주소
     */
-    constructor(address _councilAddress) public {
+    constructor(address _councilAddress) public validAddress(_councilAddress) {
         council = CouncilInterface(_councilAddress);
     }
 

--- a/contracts/deposit/DepositPool.sol
+++ b/contracts/deposit/DepositPool.sol
@@ -6,6 +6,7 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 import "contracts/token/ContractReceiver.sol";
 import "contracts/council/CouncilInterface.sol";
+import "contracts/deposit/DepositPoolInterface.sol";
 //import "contracts/council/FundManagerInterface.sol";
 //import "contracts/council/Fund.sol";
 import "contracts/utils/ExtendsOwnable.sol";
@@ -18,7 +19,7 @@ import "contracts/utils/ValidValue.sol";
  *      신고자에 대한 보상으로 특정 금액을 전송.
  *      작품 완결 시 서포터 정산 후 작가에게 잔액 전송.
  */
-contract DepositPool is ExtendsOwnable, ValidValue, ContractReceiver {
+contract DepositPool is ExtendsOwnable, ValidValue, ContractReceiver, DepositPoolInterface {
     using SafeERC20 for ERC20;
     using SafeMath for uint256;
     using ParseLib for string;
@@ -65,6 +66,14 @@ contract DepositPool is ExtendsOwnable, ValidValue, ContractReceiver {
         token.safeTransferFrom(_from, address(this), _value);
 
         emit AddDeposit(_from, _value, _token, _data);
+    }
+
+    /**
+    * @dev 현재 기록된 Content의 Deposit 금액을 반환
+    * @param _content 확인하고자 하는 Content 주소
+    */
+    function getContentDeposit(address _content) external view returns(uint256) {
+        return contentDeposit[_content];
     }
 
     /**

--- a/contracts/deposit/DepositPool.sol
+++ b/contracts/deposit/DepositPool.sol
@@ -87,15 +87,18 @@ contract DepositPool is ExtendsOwnable, ValidValue, ContractReceiver, DepositPoo
         external
     {
         require(address(council) == msg.sender);
-        require(contentDeposit[_content] > 0);
 
-        ERC20 token = ERC20(council.getToken());
-        uint256 amount = contentDeposit[_content].mul(council.getReportRewardRate()).div(100);
+        uint256 amount;
+        if (contentDeposit[_content] > 0) {
+            ERC20 token = ERC20(council.getToken());
+            amount = contentDeposit[_content].mul(council.getReportRewardRate()).div(100);
 
-        require(token.balanceOf(address(this)) >= amount);
-        contentDeposit[_content] = contentDeposit[_content].sub(amount);
-        token.safeTransfer(_reporter, amount);
-
+            require(token.balanceOf(address(this)) >= amount);
+            contentDeposit[_content] = contentDeposit[_content].sub(amount);
+            token.safeTransfer(_reporter, amount);
+        } else {
+            amount = 0;
+        }
         emit ReportReward(_content, _reporter, amount);
     }
 

--- a/contracts/deposit/DepositPool.sol
+++ b/contracts/deposit/DepositPool.sol
@@ -7,6 +7,7 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "contracts/token/ContractReceiver.sol";
 import "contracts/council/CouncilInterface.sol";
 import "contracts/deposit/DepositPoolInterface.sol";
+import "contracts/report/ReportInterface.sol";
 //import "contracts/council/FundManagerInterface.sol";
 //import "contracts/council/Fund.sol";
 import "contracts/utils/ExtendsOwnable.sol";
@@ -107,6 +108,10 @@ contract DepositPool is ExtendsOwnable, ValidValue, ContractReceiver, DepositPoo
     * @param _content 정산을 원하는 작품 주소
     */
     function release(address _content) validAddress(_content) external {
+
+        //신고 건이 있으면 완결처리되지 않음
+        require(ReportInterface(council.getReport()).getReportCount(_content) == 0);
+        
         //작품 완결 시 서포터 비율 가져오고 정산 후 작가에게 정산
         // 누가 실행 시켜야 하는가??
 

--- a/contracts/deposit/DepositPoolInterface.sol
+++ b/contracts/deposit/DepositPoolInterface.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.4.24;
+
+interface DepositPoolInterface {
+    function reportReward(address _content, address _reporter) external;
+}

--- a/contracts/deposit/DepositPoolInterface.sol
+++ b/contracts/deposit/DepositPoolInterface.sol
@@ -2,5 +2,4 @@ pragma solidity ^0.4.24;
 
 interface DepositPoolInterface {
     function reportReward(address _content, address _reporter) external;
-    function getContentDeposit(address _content) external view returns(uint256);
 }

--- a/contracts/deposit/DepositPoolInterface.sol
+++ b/contracts/deposit/DepositPoolInterface.sol
@@ -2,4 +2,5 @@ pragma solidity ^0.4.24;
 
 interface DepositPoolInterface {
     function reportReward(address _content, address _reporter) external;
+    function getContentDeposit(address _content) external view returns(uint256);
 }

--- a/contracts/report/Report.sol
+++ b/contracts/report/Report.sol
@@ -70,7 +70,6 @@ contract Report is ExtendsOwnable, ValidValue, ContractReceiver, ReportInterface
     function addRegistrationFee(address _from, uint256 _value, address _token) private {
         require(council.getReportRegistrationFee() == _value);
         require(registrationFee[msg.sender].amount == 0);
-        require(registrationFee[msg.sender].blockTime < TimeLib.currentTime());
         ERC20 token = ERC20(council.getToken());
         require(address(token) == _token);
 

--- a/contracts/report/Report.sol
+++ b/contracts/report/Report.sol
@@ -1,0 +1,192 @@
+pragma solidity ^0.4.24;
+
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
+import "contracts/token/ContractReceiver.sol";
+import "contracts/council/CouncilInterface.sol";
+
+import "contracts/report/ReportInterface.sol";
+
+import "contracts/utils/ExtendsOwnable.sol";
+import "contracts/utils/ValidValue.sol";
+import "contracts/utils/TimeLib.sol";
+
+contract Report is ExtendsOwnable, ValidValue, ContractReceiver, ReportInterface {
+
+    using SafeMath for uint256;
+    using SafeERC20 for ERC20;
+
+    //위원회
+    CouncilInterface council;
+
+    //유저 등록금
+    // amount 등록금의 양
+    // lockTime 잠김이 풀리는 시간
+    // blockTime 다시 활동이 가능한 시간
+    struct Registration {
+        uint256 amount;
+        uint256 lockTime;
+        uint256 blockTime;
+    }
+    mapping (address => Registration) registrationFee;
+
+    //신고자 등록금 잠금 시간
+    uint256 interval = 10 minutes; //for test
+
+    //신고내용과 처리유무
+    struct ReportData {
+        address content;
+        address reporter;
+        string detail;
+        bool complete;
+    }
+    //신고 목록
+    ReportData[] reports;
+
+    /**
+    * @dev 생성자
+    * @param _councilAddress 위원회 주소
+    */
+    constructor(address _councilAddress) public {
+        council = CouncilInterface(_councilAddress);
+    }
+
+    /**
+    * @dev Token의 ApproveAndCall이 호출하는 Contract의 함수
+    * @param _from 토큰을 보내는 주소
+    * @param _value 토큰의 양
+    * @param _token 토큰의 주소
+    * @param _jsonData 전달되는 데이터
+    */
+    function receiveApproval(address _from, uint256 _value, address _token, string _jsonData) public {
+        addRegistrationFee(_from, _value, _token);
+    }
+
+    /**
+    * @dev receiveApproval의 구현, token을 전송 받고 신고자의 등록금을 기록함
+    */
+    function addRegistrationFee(address _from, uint256 _value, address _token) private {
+        require(council.getReportRegistrationFee() == _value);
+        require(registrationFee[msg.sender].amount == 0);
+        require(registrationFee[msg.sender].blockTime < TimeLib.currentTime());
+        ERC20 token = ERC20(council.getToken());
+        require(address(token) == _token);
+
+        registrationFee[msg.sender].amount = _value;
+        registrationFee[msg.sender].lockTime = TimeLib.currentTime().add(interval);
+        token.safeTransferFrom(_from, address(this), _value);
+
+        emit AddRegistrationFee(_from, _value, _token);
+    }
+
+    /**
+    * @dev 신고자가 어떤 작품에 대해 신고를 함, 위원회의 보증금 변경과 관계없이 동작함(추후 논의)
+    * @param _detail 신고정보
+    */
+    function sendReport(address _content, string _detail) external validString(_detail) {
+        require(registrationFee[msg.sender].amount > 0);
+        require(registrationFee[msg.sender].blockTime < TimeLib.currentTime());
+
+        reports.push(ReportData(_content, msg.sender, _detail, false));
+
+        emit SendReport(msg.sender, _detail);
+    }
+
+    /**
+    * @dev 신고한 내용을 가져옴 (String Array를 사용하지 못함으로 한건씩 조회 필요)
+    * @param _index 신고 목록의 인덱스
+    */
+    function getReport(uint256 _index)
+        external
+        view
+        returns(address content, address reporter, string detail, bool complete)
+    {
+        content = reports[_index].content;
+        reporter = reports[_index].reporter;
+        detail = reports[_index].detail;
+        complete = reports[_index].complete;
+    }
+
+    /**
+    * @dev 신고 목록의 길이
+    */
+    function getReportsLength() external view returns(uint256) {
+        return reports.length;
+    }
+
+    /**
+    * @dev 신고 처리 완료 후 호출하는 메소드, deduction나 DepositPool의 reportReward 처리 후 호출
+    * @param _index 신고 목록의 인덱스
+    */
+    function completeReport(uint256 _index) external {
+        require(msg.sender == address(council));
+        require(_index < reports.length);
+
+        reports[_index].complete = true;
+
+        emit CompleteReport(_index, reports[_index].detail);
+    }
+
+    /**
+    * @dev 신고자의 무효, 증거 불충분으로 인한 RegFee 차감, 위원회가 호출함
+    * @param _reporter 차감 시킬 대상
+    * @param _rate 차감 시킬 비율
+    * @param _block 특정시간 행동 페널티를 줄것
+    */
+    function deduction(address _reporter, uint256 _rate, bool _block)
+        external
+        validAddress(_reporter)
+        validRange(_rate)
+    {
+        require(msg.sender == address(council));
+        require(registrationFee[_reporter].amount > 0);
+
+        uint256 result = registrationFee[_reporter].amount.mul(_rate).div(100);
+        registrationFee[_reporter].amount = registrationFee[_reporter].amount.sub(result);
+
+        ERC20 token = ERC20(council.getToken());
+        //임시 Ecosystem Growth Fund가 없음으로 위원회로 전송함
+        token.safeTransfer(address(council), result);
+
+        if (_block) {
+            registrationFee[_reporter].blockTime = registrationFee[_reporter].lockTime;
+        }
+
+        emit Deduction(_reporter, _rate, result, _block);
+    }
+
+    /**
+    * @dev 신고자가 맞긴 보증금을 찾아감
+    */
+    function returnRegFee() external {
+        require(registrationFee[msg.sender].amount > 0);
+        require(registrationFee[msg.sender].lockTime < TimeLib.currentTime());
+
+        ERC20 token = ERC20(council.getToken());
+        uint256 tempAmount = registrationFee[msg.sender].amount;
+
+        registrationFee[msg.sender].amount = 0;
+        token.safeTransfer(msg.sender, tempAmount);
+
+        emit ReturnRegFee(msg.sender, tempAmount);
+    }
+
+    /**
+    * @dev 신고자가 자신이 맞긴 등록금을 확인
+    */
+    function getRegFee() external view returns(uint256, uint256, uint256) {
+        require(registrationFee[msg.sender].amount > 0);
+        return (registrationFee[msg.sender].amount,
+            registrationFee[msg.sender].lockTime,
+            registrationFee[msg.sender].blockTime);
+    }
+
+    event AddRegistrationFee(address _from, uint256 _value, address _token);
+    event SendReport(address _from, string _detail);
+    event ReturnRegFee(address _to, uint256 _amount);
+    event CompleteReport(uint256 _index, string _detail);
+    event Deduction(address _reporter, uint256 _rate, uint256 _amount, bool _block);
+
+}

--- a/contracts/report/Report.sol
+++ b/contracts/report/Report.sol
@@ -118,6 +118,18 @@ contract Report is ExtendsOwnable, ValidValue, ContractReceiver, ReportInterface
     }
 
     /**
+    * @dev 작품의 신고 건수가 있는지 확인
+    * @param _content 확인할 작품의 주소
+    */
+    function getReportCount(address _content) external view returns(uint256 count){
+        for(uint256 i = 0; i < reports.length; i++) {
+            if (reports[i].content == _content) {
+                count = count.add(1);
+            }
+        }
+    }
+
+    /**
     * @dev 신고 처리 완료 후 호출하는 메소드, deduction나 DepositPool의 reportReward 처리 후 호출
     * @param _index 신고 목록의 인덱스
     */

--- a/contracts/report/Report.sol
+++ b/contracts/report/Report.sol
@@ -88,7 +88,6 @@ contract Report is ExtendsOwnable, ValidValue, ContractReceiver, ReportInterface
     function sendReport(address _content, string _detail) external validString(_detail) {
         require(registrationFee[msg.sender].amount > 0);
         require(registrationFee[msg.sender].blockTime < TimeLib.currentTime());
-        require(DepositPoolInterface(council.getDepositPool()).getContentDeposit(_content) > 0);
 
         reports.push(ReportData(_content, msg.sender, _detail, false));
 
@@ -121,7 +120,7 @@ contract Report is ExtendsOwnable, ValidValue, ContractReceiver, ReportInterface
     * @dev 작품의 신고 건수가 있는지 확인
     * @param _content 확인할 작품의 주소
     */
-    function getReportCount(address _content) external view returns(uint256 count){
+    function getReportCount(address _content) external view returns(uint256 count) {
         for(uint256 i = 0; i < reports.length; i++) {
             if (reports[i].content == _content) {
                 count = count.add(1);

--- a/contracts/report/Report.sol
+++ b/contracts/report/Report.sol
@@ -50,7 +50,7 @@ contract Report is ExtendsOwnable, ValidValue, ContractReceiver, ReportInterface
     * @dev 생성자
     * @param _councilAddress 위원회 주소
     */
-    constructor(address _councilAddress) public {
+    constructor(address _councilAddress) public validAddress(_councilAddress) {
         council = CouncilInterface(_councilAddress);
     }
 
@@ -135,6 +135,7 @@ contract Report is ExtendsOwnable, ValidValue, ContractReceiver, ReportInterface
     function completeReport(uint256 _index) external {
         require(msg.sender == address(council));
         require(_index < reports.length);
+        require(!reports[_index].complete);
 
         reports[_index].complete = true;
 
@@ -189,7 +190,6 @@ contract Report is ExtendsOwnable, ValidValue, ContractReceiver, ReportInterface
     * @dev 신고자가 자신이 맞긴 등록금을 확인
     */
     function getRegFee() external view returns(uint256, uint256, uint256) {
-        require(registrationFee[msg.sender].amount > 0);
         return (registrationFee[msg.sender].amount,
             registrationFee[msg.sender].lockTime,
             registrationFee[msg.sender].blockTime);

--- a/contracts/report/Report.sol
+++ b/contracts/report/Report.sol
@@ -8,6 +8,7 @@ import "contracts/token/ContractReceiver.sol";
 import "contracts/council/CouncilInterface.sol";
 
 import "contracts/report/ReportInterface.sol";
+import "contracts/deposit/DepositPoolInterface.sol";
 
 import "contracts/utils/ExtendsOwnable.sol";
 import "contracts/utils/ValidValue.sol";
@@ -87,6 +88,7 @@ contract Report is ExtendsOwnable, ValidValue, ContractReceiver, ReportInterface
     function sendReport(address _content, string _detail) external validString(_detail) {
         require(registrationFee[msg.sender].amount > 0);
         require(registrationFee[msg.sender].blockTime < TimeLib.currentTime());
+        require(DepositPoolInterface(council.getDepositPool()).getContentDeposit(_content) > 0);
 
         reports.push(ReportData(_content, msg.sender, _detail, false));
 

--- a/contracts/report/ReportInterface.sol
+++ b/contracts/report/ReportInterface.sol
@@ -3,4 +3,5 @@ pragma solidity ^0.4.24;
 interface ReportInterface {
     function completeReport(uint256 _index) external;
     function deduction(address _reporter, uint256 _rate, bool _block) external;
+    function getReportCount(address _content) external view returns(uint256);
 }

--- a/contracts/report/ReportInterface.sol
+++ b/contracts/report/ReportInterface.sol
@@ -1,0 +1,6 @@
+pragma solidity ^0.4.24;
+
+interface ReportInterface {
+    function completeReport(uint256 _index) external;
+    function deduction(address _reporter, uint256 _rate, bool _block) external;
+}


### PR DESCRIPTION
1. 신고자가 Report 주소로 위원회가 정한 보증금 만큼 토큰을 보냄(approveAndCall)
2. 신고자가 신고를 작성함
3. 위원회가 신고 목록을 보고 확인 후 리워드를 줄 것인지 보증금을 차감할 것인지 결정

논의 필요
1. 현재 보증금 차감 비율이 50% 이상이면 해당 보증금 잠금 기간동안 신고 작성이 금지됨, 
몇 %로 정할 건지 아니면 다른 방법을 사용할 것인지?
2. 신고 내용이 string 으로 저장되기에 신고 목록을 조회 시 string array가 반환이 안됨,
목록의 length 확인 후 하나씩 조회 필요하며 차후 DB에 저장하는 방향으로 가야함
3. 백서상에는 매월 단위로 신고자를 모집하고 운영하나 
구현은 각각 신고자마다 보증금을 납입한 날짜부터 interval이 지난 후 보증금을 찾을 수 있음

