### PR TITLE
Marketer Test Code 작성 및 Contract 수정 (key 생성과 mapping을 분리)

### DIFF
--- a/contracts/marketer/Marketer.sol
+++ b/contracts/marketer/Marketer.sol
@@ -1,15 +1,13 @@
 pragma solidity ^0.4.24;
 
-import "contracts/utils/ExtendsOwnable.sol";
 import "contracts/marketer/MarketerInterface.sol";
-import "contracts/utils/ValidValue.sol";
 
 /**
  * @title Marketer contract
  *
  * @author Junghoon Seo - <jh.seo@battleent.com>
  */
-contract Marketer is ExtendsOwnable, MarketerInterface, ValidValue {
+contract Marketer is MarketerInterface {
     mapping (bytes32 => address) marketerInfo;
 
     function generateMarketerKey() public returns(bytes32) {
@@ -17,8 +15,8 @@ contract Marketer is ExtendsOwnable, MarketerInterface, ValidValue {
         return key;
     }
 
-    function setMarketerKey(address _marketer, bytes32 _key) external onlyOwner validAddress(_marketer) {
-        marketerInfo[_key] = _marketer;
+    function setMarketerKey(bytes32 _key) external {
+        marketerInfo[_key] = msg.sender;
     }
 
     function getMarketerAddress(bytes32 _key) public view returns(address) {

--- a/contracts/marketer/Marketer.sol
+++ b/contracts/marketer/Marketer.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.24;
 
+import "contracts/utils/ExtendsOwnable.sol";
 import "contracts/marketer/MarketerInterface.sol";
 import "contracts/utils/ValidValue.sol";
 
@@ -8,17 +9,19 @@ import "contracts/utils/ValidValue.sol";
  *
  * @author Junghoon Seo - <jh.seo@battleent.com>
  */
-contract Marketer is MarketerInterface, ValidValue {
-  mapping (bytes32 => address) marketerInfo;
+contract Marketer is ExtendsOwnable, MarketerInterface, ValidValue {
+    mapping (bytes32 => address) marketerInfo;
 
-  function getMarketerKey() public returns(bytes32) {
-      bytes32 key = bytes32(keccak256(abi.encodePacked(msg.sender)));
-      marketerInfo[key] = msg.sender;
+    function generateMarketerKey() public returns(bytes32) {
+        bytes32 key = bytes32(keccak256(abi.encodePacked(msg.sender)));
+        return key;
+    }
 
-      return key;
-  }
+    function setMarketerKey(address _marketer, bytes32 _key) external onlyOwner validAddress(_marketer) {
+        marketerInfo[_key] = _marketer;
+    }
 
-  function getMarketerAddress(bytes32 _key) public view returns(address) {
-      return marketerInfo[_key];
-  }
+    function getMarketerAddress(bytes32 _key) public view returns(address) {
+        return marketerInfo[_key];
+    }
 }

--- a/contracts/marketer/MarketerInterface.sol
+++ b/contracts/marketer/MarketerInterface.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.24;
 
 contract MarketerInterface {
-    function getMarketerKey() public returns(bytes32);
+    function generateMarketerKey() public returns(bytes32);
     function getMarketerAddress(bytes32 _key) public view returns(address);
 }

--- a/contracts/marketer/MarketerInterface.sol
+++ b/contracts/marketer/MarketerInterface.sol
@@ -2,5 +2,6 @@ pragma solidity ^0.4.24;
 
 contract MarketerInterface {
     function generateMarketerKey() public returns(bytes32);
+    function setMarketerKey(bytes32 _key) external;
     function getMarketerAddress(bytes32 _key) public view returns(address);
 }

--- a/test/contract/marketer.test.js
+++ b/test/contract/marketer.test.js
@@ -1,0 +1,30 @@
+const Marketer = artifacts.require("Marketer");
+
+const BigNumber = web3.BigNumber;
+
+require("chai")
+    .use(require("chai-as-promised"))
+    .use(require("chai-bignumber")(BigNumber))
+    .should();
+
+
+contract("Marketer", function (accounts) {
+    const owner = accounts[0];
+    const marketerUser = accounts[1];
+
+    const decimals = Math.pow(10, 18);
+
+    let marketer;
+
+    beforeEach("Setup contract", async () => {
+        marketer = await Marketer.new({from: owner});
+    });
+
+    it("generate marketerKey and check the key.", async () => {
+        const marketerKey = await marketer.generateMarketerKey.call({from: marketerUser});
+        await marketer.setMarketerKey(marketerUser, marketerKey, {from: owner});
+
+        const marketerAddress = await marketer.getMarketerAddress.call(marketerKey, {from: owner});
+        marketerAddress.should.be.equal(marketerUser);
+    });
+});

--- a/test/contract/marketer.test.js
+++ b/test/contract/marketer.test.js
@@ -22,7 +22,7 @@ contract("Marketer", function (accounts) {
 
     it("generate marketerKey and check the key.", async () => {
         const marketerKey = await marketer.generateMarketerKey.call({from: marketerUser});
-        await marketer.setMarketerKey(marketerUser, marketerKey, {from: owner});
+        await marketer.setMarketerKey(marketerKey, {from: marketerUser});
 
         const marketerAddress = await marketer.getMarketerAddress.call(marketerKey, {from: owner});
         marketerAddress.should.be.equal(marketerUser);


### PR DESCRIPTION
Marketer Contract를 수정하였습니다.

Marketer key 생성 시 트랜잭션이 끝날때까지 키를 기다려야 하는 상황이기 때문에
key는 바로 생성하여 전달해주고 key와 marketer address를 따로 저장하는 방식으로 변경하였습니다.

또한 테스트에도 기존 getMarketerKey를 call로 호출 시 실제 트랜잭션이 일어나지 않아 
mapping에 값이 저장되지 않고 address를 0x00..으로 리턴하고 있는데 
키생성과 mapping을 분리하여서 테스트가 가능합니다.

테스트 코드도 같이 commit합니다.