### PR TITLE
PxlDistributor 파라미터 변경 / converting 함수 코드 ParseLib로 이동

### DIFF
--- a/contracts/distributor/PxlDistributor.sol
+++ b/contracts/distributor/PxlDistributor.sol
@@ -95,7 +95,7 @@ contract PxlDistributor is Ownable, ContractReceiver, ValidValue {
 
             // marketer amount
             if(ParseLib.getJsonToMarketerAddr(tokens, _jsonData) != address(0)) {
-                tempVar = getRateToPxlAmount(_value, ContentInterface(ParseLib.getJsonToContentAddr(tokens, _jsonData)).getMarketerRate());
+                tempVar = getRateToPxlAmount(_value, getMarketerRate(tokens, _jsonData));
                 compareAmount = compareAmount.sub(tempVar);
                 distribution.push(
                     DistributionDetail(
@@ -166,12 +166,14 @@ contract PxlDistributor is Ownable, ContractReceiver, ValidValue {
         return _amount.mul(_rate).div(100);
     }
 
-    function getMarketerAddress(bytes32 _key)
+    function getMarketerRate(JsmnSolLib.Token[] _tokens, string _jsonData)
         private
         view
-        returns (address)
+        returns (uint256 rate)
     {
-        return MarketerInterface(council.getMarketer()).getMarketerAddress(_key);
+        uint256 contentRate = ContentInterface(ParseLib.getJsonToContentAddr(tokens, _jsonData)).getMarketerRate();
+
+        rate = (contentRate > 0) ? contentRate : council.getMarketerDefaultRate();
     }
 
     function transferDistributePxl(address _to, uint256 _amount, bool _isCustom, string _param)

--- a/contracts/utils/ParseLib.sol
+++ b/contracts/utils/ParseLib.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.4.24;
 
+import "contracts/utils/JsmnSolLib.sol";
+
 library ParseLib {
 
     function strConcat(string _a, string _b, string _c, string _d, string _e) internal pure returns (string){
@@ -101,5 +103,74 @@ library ParseLib {
     function char(byte b) internal pure returns (byte c) {
         if (b < 10) return byte(uint8(b) + 0x30);
         else return byte(uint8(b) + 0x57);
+    }
+
+    function getJsonToCdAddr(JsmnSolLib.Token[] _tokens, string _jsonData)
+        internal
+        pure
+        returns (address)
+    {
+        return parseAddr(getTokenToValue(_tokens, _jsonData, 2));
+    }
+
+    function getJsonToContentAddr(JsmnSolLib.Token[] _tokens, string _jsonData)
+        internal
+        pure
+        returns (address)
+    {
+        return parseAddr(getTokenToValue(_tokens, _jsonData, 4));
+    }
+
+    function getJsonToEpisodeIndex(JsmnSolLib.Token[] _tokens, string _jsonData)
+        internal
+        pure
+        returns (uint256)
+    {
+        return uint256(parseInt(getTokenToValue(_tokens, _jsonData, 6)));
+    }
+
+    function getJsonToMarketerAddr(JsmnSolLib.Token[] _tokens, string _jsonData)
+        internal
+        view
+        returns (address)
+    {
+        return parseAddr(getTokenToValue(_tokens, _jsonData, 8));
+    }
+
+    function getJsonToValue(string  _jsonData, uint256 _arrayLength, uint256 _valueIndex)
+        internal
+        pure
+        returns (string)
+    {
+        uint256 returnValue;
+        JsmnSolLib.Token[] memory tokens;
+
+        (returnValue, tokens) = getJsonToTokens(_jsonData, _arrayLength);
+
+        return getTokenToValue(tokens, _jsonData, _valueIndex);
+    }
+
+    function getJsonToTokens(string _jsonData, uint256 _arrayLength)
+        internal
+        pure
+        returns (uint256, JsmnSolLib.Token[])
+    {
+        uint256 returnValue;
+        uint256 actualNum;
+        JsmnSolLib.Token[] memory tokens;
+
+        (returnValue, tokens, actualNum) = JsmnSolLib.parse(_jsonData, _arrayLength);
+
+        return (returnValue, tokens);
+    }
+
+    function getTokenToValue(JsmnSolLib.Token[] _tokens, string  _jsonData, uint256 _index)
+        internal
+        pure
+        returns (string)
+    {
+        JsmnSolLib.Token memory t = _tokens[_index];
+
+        return JsmnSolLib.getBytes(_jsonData, t.start, t.end);
     }
 }


### PR DESCRIPTION
- CD에서 전달 받는 Marketer key(bytes32)를 사용하지 않고 Marketer address로 전달 받도록 수정
	- 컨트랙트에서 변환하는 작업을 제거하여 가스 비용 절감 
	- javascript로 간단하게 bytes32 => address 변환
- PxlDistributor에서 json 문자열을 주소 등으로 변환하는 코드를 library로 이동하여 코드 정리